### PR TITLE
Install ruby bundler

### DIFF
--- a/ruby.wake
+++ b/ruby.wake
@@ -72,11 +72,11 @@ target installRubyEnv gemDir =
         | getJobOutputs
 
     # Invoke the bundler to install gems.
-    def cmd = ("{gem}/bin/bundle", "install", "--path={gem}", "--no-cache", "--standalone", "--quiet", "--gemfile={gemFile.getPathName}",  "--binstubs=.gem/bin", Nil)
+    def cmd = ("{gem}/bin/bundle", "install", "--path={gem}", "--no-cache", "--standalone", "--quiet", "--gemfile={gemFile.getPathName}", "--binstubs=.gem/bin", Nil)
     def bundlerOut =
         makePlan cmd (gemFile, lock, bundlerInstallOut)
         | editPlanResources ("ruby/ruby/2.5.1", _)
-        | setPlanEnvironmentVar "BUNDLE_HOME"  "build/{gemDir}"
+        | setPlanEnvironmentVar "HOME"  "{workspace}/build/{gemDir}"  # Needs to be an absolute path to suppress "/ not writable" message.
         | runJob
         | getJobOutputs
 


### PR DESCRIPTION
Install the ruby bundler rather than getting it from the environment.

In Ruby 3.0, the bundler becomes an integral part of rubygems.
In Ruby 2.7, the bundler is a dependent of rubygems.
However, we can't rely on it being present for earlier versions of Ruby.
To be safe, download the bundler before installing the rest of the Ruby gems.