### PR TITLE
Fix Python environment

### DIFF
--- a/install-python-pipenv
+++ b/install-python-pipenv
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Create a Python virtual environment with dependencies from a Pipfile"
+  echo "Usage: $(basename "$0") <pipfile> <pipfile-lock> <venv-dir>"
+}
+
+if [[ $# -ne 3 ]]; then
+  usage
+  exit 1
+fi
+
+pipfile="$1"
+pipfile_lock="$2"
+venv_dir="$3"
+
+if [[ $(dirname "$pipfile") != $(dirname "$pipfile_lock") ]]; then
+  echo "Pipfile and Pipfile.lock must be in the same directory."
+  exit 2
+fi
+
+# Create virtual environment
+mkdir -p "$venv_dir"
+# Note: The --copies flag is important here because it tells venv to copy
+# rather than symlink in library files, which is important for the virtual
+# environment to function properly in a sandboxed Wake execution.
+python3.7 -m venv --copies "$venv_dir"
+
+# Install pipenv into virtual environment
+"${venv_dir}/bin/pip" install pipenv==v2018.10.13
+
+# Activate virtual environment and have pipenv install packages from
+# Pipfile.lock into the virtual environment.
+. "${venv_dir}/bin/activate"
+PIPENV_PIPFILE="$pipfile" pipenv sync

--- a/python.wake
+++ b/python.wake
@@ -29,15 +29,15 @@
 ##########################################################
 global def addPythonEnv pipDir plan =
 
-    # Install the virtual environment if not already done
-    def installed = installPipenvEnv pipDir
-    def venv = "build/{pipDir}/.venv"
+  # Install the virtual environment if not already done
+  def installed = installPipenvEnv pipDir
+  def venv = "build/{pipDir}/.venv"
 
-    # Add the binary directory to PATH.
-    plan
-    | editPlanVisible (installed ++ _)
-    | addPlanEnvironmentPath  "PYTHONPATH"  venv
-    | addPlanEnvironmentPath  "PATH" "{venv}/bin"
+  # Add the binary directory to PATH.
+  plan
+  | editPlanVisible (installed ++ _)
+  | addPlanEnvironmentPath  "PYTHONPATH"  venv
+  | addPlanEnvironmentPath  "PATH" "{venv}/bin"
 
 
 ###########################################################################
@@ -67,40 +67,40 @@ global def pythonModule module args = ("python3", "-B", "-m", module, args)
 ################################################################################
 target installPipenvEnv pipDir =
 
-   # Where we will install the virtual environment.
-   def venv = "build/{pipDir}/.venv"
+  # Where we will install the virtual environment.
+  def venv = "build/{pipDir}/.venv"
 
-   # Step 1 - Copy Pipfile.lock to the build directory. Pipfile is just along for the ride.
-   def pipFile = installIn "build" (source "{pipDir}/Pipfile")
-   def lock = installIn "build" (source "{pipDir}/Pipfile.lock")
+  # Step 1 - Copy Pipfile.lock to the build directory. Pipfile is just along for the ride.
+  def pipFile = installIn "build" (source "{pipDir}/Pipfile")
+  def lock = installIn "build" (source "{pipDir}/Pipfile.lock")
 
-   # Step 2 - Running from the build directory, use pip to install pipenv in .venv/bin
-   def pipOutputs =
-      makePlan ("pip3", "install", "--target=.venv", "pipenv", Nil) (pipFile, lock, Nil)
-      | setPlanLocalOnly True   # TODO: Remove when wake problem is fixed.
-      | setPlanFnOutputs (\_ venv, Nil)  # TODO: Remove when wake problem is fixed.
-      | setPlanResources ("python/python/3.7.1", Nil)
-      | setPlanDirectory "build/{pipDir}"
-      | runJob
-      | getJobOutputs
-
-   # Step 3 - use pipenv and Pipfile.lock to install everything else in .venv.
-   def pipenvOutputs =
-     makePlan (".venv/bin/pipenv",  "sync", "--dev", Nil) (pipFile, lock, pipOutputs)
-     | setPlanLocalOnly True       # TODO: remove when wake problem is resolved
-     | setPlanFnOutputs ( \_ remove venv (files venv `.*`) ) # TODO: remove when wake problem is resolved
+  # Step 2 - Running from the build directory, use pip to install pipenv in .venv/bin
+  def pipOutputs =
+     makePlan ("pip3", "install", "--target=.venv", "pipenv", Nil) (pipFile, lock, Nil)
+     | setPlanLocalOnly True   # TODO: Remove when wake problem is fixed.
+     | setPlanFnOutputs (\_ venv, Nil)  # TODO: Remove when wake problem is fixed.
      | setPlanResources ("python/python/3.7.1", Nil)
-     | setPlanEnvironmentVar "PIPENV_VENV_IN_PROJECT" "YES"
-     | addPlanEnvironmentPath "PYTHONPATH" ".venv"  # Needed to run the installed pipenv on Linux (sifive gamma)
      | setPlanDirectory "build/{pipDir}"
      | runJob
      | getJobOutputs
 
-   # Our return value is all of the files installed.
-   pipenvOutputs ++ pipOutputs
+  # Step 3 - use pipenv and Pipfile.lock to install everything else in .venv.
+  def pipenvOutputs =
+    makePlan (".venv/bin/pipenv",  "sync", "--dev", Nil) (pipFile, lock, pipOutputs)
+    | setPlanLocalOnly True       # TODO: remove when wake problem is resolved
+    | setPlanFnOutputs ( \_ remove venv (files venv `.*`) ) # TODO: remove when wake problem is resolved
+    | setPlanResources ("python/python/3.7.1", Nil)
+    | setPlanEnvironmentVar "PIPENV_VENV_IN_PROJECT" "YES"
+    | addPlanEnvironmentPath "PYTHONPATH" ".venv"  # Needed to run the installed pipenv on Linux (sifive gamma)
+    | setPlanDirectory "build/{pipDir}"
+    | runJob
+    | getJobOutputs
+
+  # Our return value is all of the files installed.
+  pipenvOutputs ++ pipOutputs
 
 
 
 # Remove a string from a list of strings.
 def remove string strings =
-    filter (_ !=~ string) strings
+  filter (_ !=~ string) strings

--- a/python.wake
+++ b/python.wake
@@ -53,8 +53,8 @@ global def pythonInstaller pipdir Unit =
 #######################################################################################
 # Commands for running Python. We suppress byte code since it causes concurrency problems with Wake.
 ######################################################################################
-global def pythonCommand script args = ("python3", "-B", script, args)
-global def pythonModule module args = ("python3", "-B", "-m", module, args)
+global def pythonCommand script args = ("python3.7", "-B", script, args)
+global def pythonModule module args = ("python3.7", "-B", "-m", module, args)
 
 
 
@@ -69,35 +69,23 @@ target installPipenvEnv pipDir =
 
   # Where we will install the virtual environment.
   def venv = "build/{pipDir}/.venv"
-
-  # Step 1 - Copy Pipfile.lock to the build directory. Pipfile is just along for the ride.
   def pipFile = installIn "build" (source "{pipDir}/Pipfile")
   def lock = installIn "build" (source "{pipDir}/Pipfile.lock")
+  def installPipenvScript = source "{here}/install-python-pipenv"
 
-  # Step 2 - Running from the build directory, use pip to install pipenv in .venv/bin
-  def pipOutputs =
-     makePlan ("pip3", "install", "--target=.venv", "pipenv", Nil) (pipFile, lock, Nil)
-     | setPlanLocalOnly True   # TODO: Remove when wake problem is fixed.
-     | setPlanFnOutputs (\_ venv, Nil)  # TODO: Remove when wake problem is fixed.
-     | setPlanResources ("python/python/3.7.1", Nil)
-     | setPlanDirectory "build/{pipDir}"
-     | runJob
-     | getJobOutputs
+  def args =
+    installPipenvScript.getPathName,
+    pipFile.getPathName,
+    lock.getPathName,
+    venv,
+    Nil
 
-  # Step 3 - use pipenv and Pipfile.lock to install everything else in .venv.
-  def pipenvOutputs =
-    makePlan (".venv/bin/pipenv",  "sync", "--dev", Nil) (pipFile, lock, pipOutputs)
-    | setPlanLocalOnly True       # TODO: remove when wake problem is resolved
-    | setPlanFnOutputs ( \_ remove venv (files venv `.*`) ) # TODO: remove when wake problem is resolved
-    | setPlanResources ("python/python/3.7.1", Nil)
-    | setPlanEnvironmentVar "PIPENV_VENV_IN_PROJECT" "YES"
-    | addPlanEnvironmentPath "PYTHONPATH" ".venv"  # Needed to run the installed pipenv on Linux (sifive gamma)
-    | setPlanDirectory "build/{pipDir}"
-    | runJob
-    | getJobOutputs
+  def visible = installPipenvScript, pipFile, lock, Nil
 
-  # Our return value is all of the files installed.
-  pipenvOutputs ++ pipOutputs
+  makePlan args visible
+  | setPlanResources ("python/python/3.7.1", Nil)
+  | runJob
+  | getJobOutputs
 
 
 


### PR DESCRIPTION
The existing Python environment setup commands create a Python virtual environment that doesn't function correctly in a sandboxed Wake environment, due to the fact that they are symlinking system files which may not be readable by the sandbox. This was specifically causing me problems with the preload runner, which is an alternative to the FUSE runner.

The main functional change that this PR makes is to explicitly create the virtual environment using the [`--copies`](https://docs.python.org/3/library/venv.html#creating-virtual-environments) flag to `python3 -m venv`, which instructs `venv` to create copies rather than symlinks to system files.

I also ended up squashing the Wake jobs into a single bash script for creating the virtual environment and installing dependencies from the Pipfile, since Wake doesn't like when two commands write to the same file, and this makes it simpler to construct the entire virtual environment directory as one atomic action.

This should be API backwards compatible with what we had before, as none of the public function arguments have changed.