### PR TITLE
Fix a problem with Ruby bundler

### DIFF
--- a/ruby.wake
+++ b/ruby.wake
@@ -76,6 +76,7 @@ target installRubyEnv gemDir =
     def bundlerOut =
         makePlan cmd (gemFile, lock, bundlerInstallOut)
         | editPlanResources ("ruby/ruby/2.5.1", _)
+        | addPlanEnvironmentPath "GEM_PATH"  "build/{gemDir}/.gem"
         | setPlanEnvironmentVar "HOME"  "{workspace}/build/{gemDir}"  # Needs to be an absolute path to suppress "/ not writable" message.
         | runJob
         | getJobOutputs


### PR DESCRIPTION
Add .gem to GEM_PATH, so the bundler command will find the freshly installed bundler gem.
Otherwise, was getting wrong version of bundler in some environments.