### PR TITLE
Updating python, ruby, node to use paths relative to plan's working directory

### DIFF
--- a/command.wake
+++ b/command.wake
@@ -30,6 +30,15 @@ global def editPlanEnvironmentPath key fn plan =
     setPlanEnvironmentPath key newPath plan
 
 
+################################################################################
+# Add a relative file path to the plan's environment variable.
+#   If a plan has set a new working directory, then
+#   this function converts the path so it is relative to the new working directory.
+#################################################################################
+global def addPlanRelativePath key path plan =
+  plan | addPlanEnvironmentPath  key (relative plan.getPlanDirectory path)
+
+
 #############################################################################
 # Get or Set an environment variable in a plan.
 #############################################################################
@@ -54,20 +63,6 @@ global def quietResult result =
 
 
 
-########################################################################################
-# Create a plan with defaults for running most system commands
-#   Basically, it is a regular default plan with additional variables
-#   required by common Linux commands or helpful to the wake environment.
-# DEPRECATED.
-#######################################################################################
-global def makeSystemPlan cmd visible =
-   makePlan cmd visible
-   | setPlanEnvironmentVar "LANG"  "en_US.UTF8"
-   | setPlanEnvironmentVar "LC_ALL"  "en_US.UTF-8"
-   | setPlanEnvironmentVar "HOME"   "/tmp"  # Need a HOME - any valid temp directory will do.
-
-
-
 ##########################################################################
 # A facility to preinstall whatever is needed by a wake project.
 #       publish preinstall = installFunction, Nil
@@ -87,4 +82,4 @@ global def preinstall Unit =
     def results = (subscribe preinstall) | map (_ Unit)
 
     # Pass silently if all of them were successful. Otherwise, Fail.
-    findFail results | rmap (\_ "")
+    findFail results | quietResult

--- a/node.wake
+++ b/node.wake
@@ -27,8 +27,8 @@ global def addNodeEnv packageDir plan =
 
     # Add the installed modules to PATH and NODE_PATH
     plan
-    | addPlanEnvironmentPath  "PATH" "build/{packageDir}/node_modules/.bin"
-    | addPlanEnvironmentPath  "NODE_PATH"  "build/{packageDir}/node_modules"
+    | addPlanRelativePath  "PATH" "build/{packageDir}/node_modules/.bin"
+    | addPlanRelativePath  "NODE_PATH"  "build/{packageDir}/node_modules"
     | editPlanVisible ( _ ++ installed )
 
 
@@ -65,12 +65,4 @@ target installNodeEnv packageDir =
     | setPlanDirectory "build/{packageDir}"
     | runJob
     | getJobOutputs
-
-
-def testNode _ =
-    def version =
-        makePlan ("node", "-v", Nil)  Nil
-        | addNodeEnv "{here}/tests"
-        | runJob | getJobStdout
-    version
 

--- a/python.wake
+++ b/python.wake
@@ -16,7 +16,7 @@
 #
 # If you wish to download python modules ahead of time,
 #      publish preinstall = (pythonInstaller "directory-containing-Pipfile"), Nil
-# and he "wake preinstall Unit" call will then download the python modules.
+# and the "wake preinstall Unit" call will then download the python modules.
 #
 #############################################################################
 
@@ -36,8 +36,8 @@ global def addPythonEnv pipDir plan =
   # Add the binary directory to PATH.
   plan
   | editPlanVisible (installed ++ _)
-  | addPlanEnvironmentPath  "PYTHONPATH"  venv
-  | addPlanEnvironmentPath  "PATH" "{venv}/bin"
+  | addPlanRelativePath  "PYTHONPATH"  venv
+  | addPlanRelativePath  "PATH" "{venv}/bin"
 
 
 ###########################################################################

--- a/ruby.wake
+++ b/ruby.wake
@@ -28,8 +28,8 @@ global def addRubyEnv gemDir plan =
 
     # Update the plan to include the installed gems and binaries
     plan
-    | addPlanEnvironmentPath "PATH" "build/{gemDir}/.gem/bin"
-    | addPlanEnvironmentPath "GEM_PATH"  "build/{gemDir}/.gem"
+    | addPlanRelativePath "PATH" "build/{gemDir}/.gem/bin"
+    | addPlanRelativePath "GEM_PATH"  "build/{gemDir}/.gem"
     | editPlanVisible (installed ++ _)
 
 


### PR DESCRIPTION
When adding a virtual environment to a plan, make sure the virtual environment paths are relative to the plan's working directory. (Applies to Python, Ruby and NodeJS virtual environments.)