### PR TITLE
Two issues: use "node ci" instead of "node install", and issue warning about bad paths installed by pipenv.

### DIFF
--- a/node.wake
+++ b/node.wake
@@ -59,7 +59,8 @@ target installNodeEnv packageDir =
     def lock = installIn "build" (source "{packageDir}/package-lock.json")
 
     # The virtual environment will be in the build directory with the new package files.
-    makePlan ("npm", "install", Nil)  (pkg, lock, Nil)
+    #  Note the use of "ci" to install. The "ci" command ensures the lock file does not get updated.
+    makePlan ("npm", "ci", Nil)  (pkg, lock, Nil)
     | setPlanLocalOnly True   # Remove when wake issue resolved
     | setPlanFnOutputs (\_ files "build/{packageDir}/node_modules" `.*`) # remove when wake issue resolved
     | setPlanDirectory "build/{packageDir}"

--- a/python.wake
+++ b/python.wake
@@ -105,11 +105,6 @@ target installPipenvEnv pipDir =
   | setPlanLocalOnly True
   | setPlanFnOutputs (\_ files venv `.*`)
 
-  # Workaround for a bug in Wake 0.15.3 and 0.17.2 when running in Docker containers.
-  #   In Docker, wake remaps file paths even though the plan is "Local Only".
-  #   Work around the problem by setting the working directory to an absolute path.
-  | setPlanDirectory workspace
-
   # Finally, run the plan and return tbe list of files installed in the venv.
   | runJob
   | getJobOutputs

--- a/python.wake
+++ b/python.wake
@@ -38,7 +38,6 @@ global def addPythonEnv pipDir plan =
   | editPlanVisible (installed ++ _)
   | addPlanRelativePath  "PYTHONPATH"  venv
   | addPlanRelativePath  "PATH" "{venv}/bin"
-  | setPlanEnvironmentVar "VIRTUAL_ENV"  venv
 
 
 ###########################################################################

--- a/python.wake
+++ b/python.wake
@@ -62,7 +62,7 @@ global def pythonModule module args = ("python3.7", "-B", "-m", module, args)
 ##############################################################################
 # Install the python environment associated with Pipfile.lock.
 #
-# NOTE: When installing to the .venv/bin directory,
+# WARNING: When installing to the .venv/bin directory,
 #   pipenv creates scripts which embed the "realpath"
 #   of the Python binary. Under Wake, these paths contain
 #   explicit references to the Fuse directories.
@@ -72,11 +72,8 @@ global def pythonModule module args = ("python3.7", "-B", "-m", module, args)
 #   when it should create the following path:
 #       /workspace/.venv/bin/python3.7
 #
-#   The invalid paths work fine during the initial Wake invocation,
-#   but they are completely invalid on subsequent invocations of Wake.
-#
-#   Ideally, we would rewrite pipenv so it doesn't use "realpath", but that isn't an option.
-#   Instead, we run pipenv outside of Fuse so it generates correct paths.
+#   There will be an upcoming fix for this problem, but for now,
+#   do not use scripts installed under pipenv's bin directory.
 #
 #################################################################################
 target installPipenvEnv pipDir =
@@ -100,10 +97,6 @@ target installPipenvEnv pipDir =
   # Create a plan to run the script and create a virtual environment.
   makePlan args visible
   | setPlanResources ("python/python/3.7.1", Nil)
-
-  # Disable Fuse since it is incompatible with pipenv.
-  | setPlanLocalOnly True
-  | setPlanFnOutputs (\_ files venv `.*`)
 
   # Finally, run the plan and return tbe list of files installed in the venv.
   | runJob

--- a/python.wake
+++ b/python.wake
@@ -38,6 +38,7 @@ global def addPythonEnv pipDir plan =
   | editPlanVisible (installed ++ _)
   | addPlanRelativePath  "PYTHONPATH"  venv
   | addPlanRelativePath  "PATH" "{venv}/bin"
+  | setPlanEnvironmentVar "VIRTUAL_ENV"  venv
 
 
 ###########################################################################
@@ -60,11 +61,24 @@ global def pythonModule module args = ("python3.7", "-B", "-m", module, args)
 
 ##############################################################################
 # Install the python environment associated with Pipfile.lock.
-#  Note we install pipenv first, then use pipenv to install the remaining modules.
-#     For the workaround, the first step returns one file, and the second step
-#     returns all the files except that one.
-#     Appended together, we have a complete set of files.
-################################################################################
+#
+# NOTE: When installing to the .venv/bin directory,
+#   pipenv creates scripts which embed the "realpath"
+#   of the Python binary. Under Wake, these paths contain
+#   explicit references to the Fuse directories.
+#
+#   So, pipenv creates invalid paths like the following:
+#       /workspace/.build/91/.venv/bin/python3.7
+#   when it should create the following path:
+#       /workspace/.venv/bin/python3.7
+#
+#   The invalid paths work fine during the initial Wake invocation,
+#   but they are completely invalid on subsequent invocations of Wake.
+#
+#   Ideally, we would rewrite pipenv so it doesn't use "realpath", but that isn't an option.
+#   Instead, we run pipenv outside of Fuse so it generates correct paths.
+#
+#################################################################################
 target installPipenvEnv pipDir =
 
   # Where we will install the virtual environment.
@@ -73,6 +87,7 @@ target installPipenvEnv pipDir =
   def lock = installIn "build" (source "{pipDir}/Pipfile.lock")
   def installPipenvScript = source "{here}/install-python-pipenv"
 
+  # Build up the command "install-python-pipe  <pipfile>  <lockfile>  <venv>"
   def args =
     installPipenvScript.getPathName,
     pipFile.getPathName,
@@ -82,13 +97,19 @@ target installPipenvEnv pipDir =
 
   def visible = installPipenvScript, pipFile, lock, Nil
 
+  # Create a plan to run the script and create a virtual environment.
   makePlan args visible
   | setPlanResources ("python/python/3.7.1", Nil)
+
+  # Disable Fuse since it is incompatible with pipenv.
+  | setPlanLocalOnly True
+  | setPlanFnOutputs (\_ files venv `.*`)
+
+  # Workaround for a bug in Wake 0.15.3 and 0.17.2 when running in Docker containers.
+  #   In Docker, wake remaps file paths even though the plan is "Local Only".
+  #   Work around the problem by setting the working directory to an absolute path.
+  | setPlanDirectory workspace
+
+  # Finally, run the plan and return tbe list of files installed in the venv.
   | runJob
   | getJobOutputs
-
-
-
-# Remove a string from a list of strings.
-def remove string strings =
-  filter (_ !=~ string) strings


### PR DESCRIPTION
Pipenv  uses "realpafh" to generate internal file paths - unfortunately, "realpath" generates invalid paths when run under Wake/Fuse. This fix restores the "setLocalOnly" mode when running pipenv under wake.

Additionally, use the "npm ci" command to install node modules.  Unlike the normal "install" command, "ci" does not update the lock file.  Updates to the lock file generate Wake errors.