### PR TITLE
use '--deployment' flag in bundle install command

### DIFF
--- a/ruby.wake
+++ b/ruby.wake
@@ -72,7 +72,7 @@ target installRubyEnv gemDir =
         | getJobOutputs
 
     # Invoke the bundler to install gems.
-    def cmd = ("{gem}/bin/bundle", "install", "--path={gem}", "--no-cache", "--standalone", "--quiet", "--gemfile={gemFile.getPathName}", "--binstubs=.gem/bin", Nil)
+    def cmd = ("{gem}/bin/bundle", "install", "--deployment", "--path={gem}", "--no-cache", "--standalone", "--quiet", "--gemfile={gemFile.getPathName}", "--binstubs=.gem/bin", Nil)
     def bundlerOut =
         makePlan cmd (gemFile, lock, bundlerInstallOut)
         | editPlanResources ("ruby/ruby/2.5.1", _)

--- a/ruby.wake
+++ b/ruby.wake
@@ -72,7 +72,7 @@ target installRubyEnv gemDir =
         | getJobOutputs
 
     # Invoke the bundler to install gems.
-    def cmd = ("{gem}/bin/bundle", "install", "--deployment", "--path={gem}", "--no-cache", "--standalone", "--quiet", "--gemfile={gemFile.getPathName}", "--binstubs=.gem/bin", Nil)
+    def cmd = ("{gem}/bin/bundle", "install", "--frozen", "--path={gem}", "--no-cache", "--standalone", "--quiet", "--gemfile={gemFile.getPathName}", "--binstubs=.gem/bin", Nil)
     def bundlerOut =
         makePlan cmd (gemFile, lock, bundlerInstallOut)
         | editPlanResources ("ruby/ruby/2.5.1", _)


### PR DESCRIPTION
to prevent `bundle install` from modifying the copied `Gemfile.lock` file. this option is deprecated though
`[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set deployment 'true'`, and stop using this flag`