### PR TITLE
set buildDir to 'build/api-languages-sifive'

### DIFF
--- a/node.wake
+++ b/node.wake
@@ -27,8 +27,8 @@ global def addNodeEnv packageDir plan =
 
     # Add the installed modules to PATH and NODE_PATH
     plan
-    | addPlanRelativePath  "PATH" "build/{packageDir}/node_modules/.bin"
-    | addPlanRelativePath  "NODE_PATH"  "build/{packageDir}/node_modules"
+    | addPlanRelativePath  "PATH" "{apiLanguagesSifiveBuildDir}/{packageDir}/node_modules/.bin"
+    | addPlanRelativePath  "NODE_PATH"  "{apiLanguagesSifiveBuildDir}/{packageDir}/node_modules"
     | editPlanVisible ( _ ++ installed )
 
 
@@ -55,15 +55,15 @@ global def nodeCommand module args  =
 ################################################################################
 target installNodeEnv packageDir =
     # Copy the package files to the build directory
-    def pkg = installIn "build" (source "{packageDir}/package.json")
-    def lock = installIn "build" (source "{packageDir}/package-lock.json")
+    def pkg = installIn apiLanguagesSifiveBuildDir (source "{packageDir}/package.json")
+    def lock = installIn apiLanguagesSifiveBuildDir (source "{packageDir}/package-lock.json")
 
     # The virtual environment will be in the build directory with the new package files.
     #  Note the use of "ci" to install. The "ci" command ensures the lock file does not get updated.
     makePlan ("npm", "ci", Nil)  (pkg, lock, Nil)
     | setPlanLocalOnly True   # Remove when wake issue resolved
-    | setPlanFnOutputs (\_ files "build/{packageDir}/node_modules" `.*`) # remove when wake issue resolved
-    | setPlanDirectory "build/{packageDir}"
+    | setPlanFnOutputs (\_ files "{apiLanguagesSifiveBuildDir}/{packageDir}/node_modules" `.*`) # remove when wake issue resolved
+    | setPlanDirectory "{apiLanguagesSifiveBuildDir}/{packageDir}"
     | runJob
     | getJobOutputs
 

--- a/python.wake
+++ b/python.wake
@@ -21,6 +21,7 @@
 #############################################################################
 
 
+global def apiLanguagesSifiveBuildDir = "build/api-languages-sifive"
 
 ######################################################
 # Add a Python virtual environment to a plan.
@@ -30,7 +31,7 @@
 global def addPythonEnv pipDir plan =
   # Install the virtual environment if not already done
   def installed = installPipenvEnv pipDir
-  def venv = "build/{pipDir}/.venv"
+  def venv = "{apiLanguagesSifiveBuildDir}/{pipDir}/.venv"
 
   # Add the binary directory to PATH.
   plan
@@ -46,7 +47,7 @@ global def addPythonEnv pipDir plan =
 global def addPythonRequirementsEnv pipDir plan =
   # Install the virtual environment if not already done
   def installed = installPythonRequirementsEnv pipDir
-  def venv = "build/{pipDir}/.venv"
+  def venv = "{apiLanguagesSifiveBuildDir}/{pipDir}/.venv"
 
   # Add the binary directory to PATH.
   plan
@@ -100,9 +101,9 @@ global def pythonModule module args = ("python3.7", "-B", "-m", module, args)
 target installPipenvEnv pipDir =
 
   # Where we will install the virtual environment.
-  def venv = "build/{pipDir}/.venv"
-  def pipFile = installIn "build" (source "{pipDir}/Pipfile")
-  def lock = installIn "build" (source "{pipDir}/Pipfile.lock")
+  def venv = "{apiLanguagesSifiveBuildDir}/{pipDir}/.venv"
+  def pipFile = installIn apiLanguagesSifiveBuildDir (source "{pipDir}/Pipfile")
+  def lock = installIn apiLanguagesSifiveBuildDir (source "{pipDir}/Pipfile.lock")
   def installPipenvScript = source "{here}/install-python-pipenv"
 
   # Build up the command "install-python-pipe  <pipfile>  <lockfile>  <venv>"
@@ -143,8 +144,8 @@ target installPipenvEnv pipDir =
 target installPythonRequirementsEnv pipDir =
 
   # Where we will install the virtual environment.
-  def venv = "build/{pipDir}/.venv"
-  def requirements = installIn "build" (source "{pipDir}/requirements.txt")
+  def venv = "{apiLanguagesSifiveBuildDir}/{pipDir}/.venv"
+  def requirements = installIn apiLanguagesSifiveBuildDir (source "{pipDir}/requirements.txt")
   def installPythonRequirementsScript = source "{here}/install-python-requirements"
 
   # Build up the command "install-python-pipe  <requirements.txt>  <venv>"

--- a/ruby.wake
+++ b/ruby.wake
@@ -28,8 +28,8 @@ global def addRubyEnv gemDir plan =
 
     # Update the plan to include the installed gems and binaries
     plan
-    | addPlanRelativePath "PATH" "build/{gemDir}/.gem/bin"
-    | addPlanRelativePath "GEM_PATH"  "build/{gemDir}/.gem"
+    | addPlanRelativePath "PATH" "{apiLanguagesSifiveBuildDir}/{gemDir}/.gem/bin"
+    | addPlanRelativePath "GEM_PATH"  "{apiLanguagesSifiveBuildDir}/{gemDir}/.gem"
     | editPlanVisible (installed ++ _)
 
 
@@ -58,11 +58,11 @@ global def rubyCommand gem arglist =
 target installRubyEnv gemDir =
 
     # Copy the package files to the build directory.
-    def gemFile = installIn "build" (source "{gemDir}/Gemfile")
-    def lock = installIn "build" (source "{gemDir}/Gemfile.lock")
+    def gemFile = installIn apiLanguagesSifiveBuildDir (source "{gemDir}/Gemfile")
+    def lock = installIn apiLanguagesSifiveBuildDir (source "{gemDir}/Gemfile.lock")
 
     # Target directory where gems are installed
-    def gem = "build/{gemDir}/.gem"
+    def gem = "{apiLanguagesSifiveBuildDir}/{gemDir}/.gem"
 
     # Install the gem bundler. Depends on gemFile, not for the gemFile but for the directory it resides in.
     def bundlerInstallOut =
@@ -76,8 +76,8 @@ target installRubyEnv gemDir =
     def bundlerOut =
         makePlan cmd (gemFile, lock, bundlerInstallOut)
         | editPlanResources ("ruby/ruby/2.5.1", _)
-        | addPlanEnvironmentPath "GEM_PATH"  "build/{gemDir}/.gem"
-        | setPlanEnvironmentVar "HOME"  "{workspace}/build/{gemDir}"  # Needs to be an absolute path to suppress "/ not writable" message.
+        | addPlanEnvironmentPath "GEM_PATH"  "{apiLanguagesSifiveBuildDir}/{gemDir}/.gem"
+        | setPlanEnvironmentVar "HOME"  "{workspace}/{apiLanguagesSifiveBuildDir}/{gemDir}"  # Needs to be an absolute path to suppress "/ not writable" message.
         | runJob
         | getJobOutputs
 


### PR DESCRIPTION
install all files to `build/api-languages-sifive` instead of `build`. This is to avoid downloading files into other repos' build directories since we follow the convention of dumping files in `build/{repo_name}`.